### PR TITLE
Add docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         pip install -e ".[dev]"
     - name: Analysing the code with mypy
       run: |
-        mypy $(git ls-files '*.py')
+        mypy $(git ls-files '*.py' | grep -v "docs/")
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint $(git ls-files '*.py' | grep -v "docs/")

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 warn_unused_configs = True
 disallow_untyped_defs = True
-exclude = venv|docs
+exclude = (venv|docs)
 
 [mypy-afdko.*]
 ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 warn_unused_configs = True
 disallow_untyped_defs = True
-exclude = venv
+exclude = venv|docs
 
 [mypy-afdko.*]
 ignore_missing_imports = True

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/commands/cff.rst
+++ b/docs/source/commands/cff.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.cff:cli
+   :prog: ftcli cff
+   :nested: full

--- a/docs/source/commands/cmap.rst
+++ b/docs/source/commands/cmap.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.cmap:cli
+   :prog: ftcli cmap
+   :nested: full

--- a/docs/source/commands/converter.rst
+++ b/docs/source/commands/converter.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.converter:cli
+   :prog: ftcli converter
+   :nested: full

--- a/docs/source/commands/fix.rst
+++ b/docs/source/commands/fix.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.fix:cli
+   :prog: ftcli fix
+   :nested: full

--- a/docs/source/commands/font.rst
+++ b/docs/source/commands/font.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.font:cli
+   :prog: ftcli font
+   :nested: full

--- a/docs/source/commands/gsub.rst
+++ b/docs/source/commands/gsub.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.gsub:cli
+   :prog: ftcli gsub
+   :nested: full

--- a/docs/source/commands/hhea.rst
+++ b/docs/source/commands/hhea.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.hhea:cli
+   :prog: ftcli hhea
+   :nested: full

--- a/docs/source/commands/name.rst
+++ b/docs/source/commands/name.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.name:cli
+   :prog: ftcli name
+   :nested: full

--- a/docs/source/commands/os2.rst
+++ b/docs/source/commands/os2.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.os_2:cli
+   :prog: ftcli os2
+   :nested: full

--- a/docs/source/commands/otf.rst
+++ b/docs/source/commands/otf.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.otf:cli
+   :prog: ftcli otf
+   :nested: full

--- a/docs/source/commands/post.rst
+++ b/docs/source/commands/post.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.post:cli
+   :prog: ftcli post
+   :nested: full

--- a/docs/source/commands/print.rst
+++ b/docs/source/commands/print.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.print:cli
+   :prog: ftcli print
+   :nested: full

--- a/docs/source/commands/ttf.rst
+++ b/docs/source/commands/ttf.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.ttf:cli
+   :prog: ftcli ttf
+   :nested: full

--- a/docs/source/commands/utils.rst
+++ b/docs/source/commands/utils.rst
@@ -1,0 +1,3 @@
+.. click:: foundrytools_cli_ng.commands.utils:cli
+   :prog: ftcli utils
+   :nested: full

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,25 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "FoundryTools-CLI-NG"
+copyright = "2025, Cesare Gilento"
+author = "Cesare Gilento"
+release = "2.0.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx_click"]
+
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ release = "2.0.0"
 
 extensions = ["sphinx_click"]
 
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,30 @@
+.. FoundryTools-CLI-NG documentation master file, created by
+   sphinx-quickstart on Tue Apr 22 13:26:19 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+FoundryTools-CLI-NG documentation
+=================================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   commands/cff
+   commands/cmap
+   commands/converter
+   commands/fix
+   commands/font
+   commands/gsub
+   commands/hhea
+   commands/name
+   commands/os2
+   commands/otf
+   commands/post
+   commands/print
+   commands/ttf
+   commands/utils
+   :maxdepth: 2
+   :caption: Contents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ dev = [
     "pre-commit>=4.2.0",
     "pylint>=3.3.6",
 ]
+docs = [
+    "sphinx>=8.3.0",
+    "sphinx-click>=6.0.0",
+    "sphinx-rtd-theme>=3.0.2",
+]
 
 [tool.hatch.version]
 path = "src/foundrytools_cli_ng/__init__.py"


### PR DESCRIPTION
This pull request introduces documentation generation using Sphinx and updates the codebase to exclude documentation files from type checking and linting. The changes include adding Sphinx configuration and documentation files, as well as updating linting and type-checking configurations to ignore the `docs/` directory.

### Documentation Setup and Configuration:

* Added a `Makefile` and `make.bat` for building Sphinx documentation, with support for common Sphinx commands (`docs/Makefile`, `docs/make.bat`). [[1]](diffhunk://#diff-cdec797dddf8fc387304501d6bd4f318e1e9067c6fae012dfa8b69fd85fd3248R1-R20) [[2]](diffhunk://#diff-eced23cf23b339d5a7dcd2246cb8fb515b1fa640975b585950c75ae19ba55febR1-R35)
* Created a Sphinx configuration file, `conf.py`, specifying project details, extensions, and HTML theme (`docs/source/conf.py`).
* Added an `index.rst` file as the main entry point for the documentation, including a table of contents for CLI command documentation (`docs/source/index.rst`).
* Added individual `.rst` files for each CLI command, auto-generating documentation using the `sphinx_click` extension (e.g., `cff.rst`, `cmap.rst`, etc.) (`docs/source/commands/*.rst`). [[1]](diffhunk://#diff-15c03afa23328959f50eeb9fafd6caf644d93181b4d47148f3c88796f7737a2fR1-R3) [[2]](diffhunk://#diff-92a26cd33159b7f14b98c2b87a76700276b8c39a6831f41299e19882875a1a2dR1-R3) [[3]](diffhunk://#diff-a8b3105d365eee207ffa59574d83ac5ccc9f1fa60c740351eb6f25326b541174R1-R3) [[4]](diffhunk://#diff-807d9558bde56bf947b576f73ab39292f4c67f7f285f7a5446e6b593b5e69d4eR1-R3) [[5]](diffhunk://#diff-6a93dd9a6584812f1bbb9767595ed56faf1b821b93ada8b177fa9b8ea664028aR1-R3) [[6]](diffhunk://#diff-190e5c5856b88d425ad82c7f5a8fd494fd8a79a2b8b0c31649e01fcfc57d6513R1-R3) [[7]](diffhunk://#diff-d96635e7216222734adb0ecd21d20936d7a8ab8ad4994a79706af822bfe814daR1-R3) [[8]](diffhunk://#diff-8c27c122002ec0832789f5d453004a79aac99e186880331f2c614aa79fd8c0d1R1-R3) [[9]](diffhunk://#diff-e70d200b9f52cf09264529f58c6d84e37c808122dbdf5f69220e69c2bce7abbdR1-R3) [[10]](diffhunk://#diff-b5fe6d15e416c036e25f7be8a8fc21bfe0b529929bbad69d2a24cf78de593286R1-R3) [[11]](diffhunk://#diff-781ad31d47b4ae0f137dfd53a5731a58a00d2dc445c13e3db76edee2c23a97e7R1-R3) [[12]](diffhunk://#diff-80c6a63265414bfe53ec4fda48ea3b0c0861c509c0d865fc87df38d41ae230b5R1-R3) [[13]](diffhunk://#diff-a7cd2060a51b576dae534f55fd4b469f4ce6928d55a678bb063e226a67da5a5cR1-R3) [[14]](diffhunk://#diff-e099eb4b1721c98b356b4d31a27b5f264fcaed1dd73778d3e66bc41c775c2754R1-R3)

### Linting and Type-Checking Updates:

* Updated `mypy` and `pylint` commands in `.github/workflows/lint.yml` to exclude files in the `docs/` directory (`.github/workflows/lint.yml`).
* Modified `.mypy.ini` to exclude the `docs/` directory from type checking (`.mypy.ini`).